### PR TITLE
Use regex from dev branch

### DIFF
--- a/src/Plugin/Filter/EmptyParagraphKiller.php
+++ b/src/Plugin/Filter/EmptyParagraphKiller.php
@@ -27,7 +27,7 @@ class EmptyParagraphKiller extends FilterBase {
    * Performs the filter processing.
    */
   public function process($text, $langcode) {
-    return new FilterProcessResult(preg_replace('#<p[^>]*>(\s|&nbsp;?)*</p>#', '', $text));
+    return new FilterProcessResult(preg_replace('/<p[^>]*>(&nbsp;|\s)*<\/p>/ui', '', $text));
   }
 
 }


### PR DESCRIPTION
The regex from the dev branch is more reliable, especially because ckeditor in D8 seems to adds `<p>&nbsp;</p>`which is somehow not replaced on my page. Changing the regex to the one in the dev branch of emptyparagraphkiller does the trick.

Thanks for the port so far Flo, saved a lot of time!
